### PR TITLE
Store only the items that matches a predicate

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ import set from 'lodash.set';
 import unset from 'lodash.unset';
 import pickBy from 'lodash.pickby';
 import isEmpty from 'lodash.isempty';
+import forIn from 'lodash.forIn';
 
 export default function createFilter (reducerName, inboundPaths, outboundPaths, transformType = 'whitelist') {
 	return createTransform(
@@ -48,7 +49,7 @@ export function persistFilter (state, paths = [], transformType = 'whitelist') {
 
 	if (transformType === 'whitelist') {
 		paths.forEach((path) => {
-			if (typeof path === 'object') {
+			if (typeof path === 'object' && !(path instanceof Array)) {
 				const value = filterObject(path, state);
 
 				if (!isEmpty(value)) {
@@ -65,11 +66,11 @@ export function persistFilter (state, paths = [], transformType = 'whitelist') {
 	} else if (transformType === 'blacklist') {
 		subset = Object.assign({}, state);
 		paths.forEach((path) => {
-			if (typeof path === 'object') {
+			if (typeof path === 'object' && !(path instanceof Array)) {
 				const value = filterObject(path, state);
 
 				if (!isEmpty(value)) {
-					unset(subset, path.path);
+					forIn(value, (value, key) => { unset(subset, `${path.path}.${key}`) });
 				}
 			} else {
 				const value = get(state, path);

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ import set from 'lodash.set';
 import unset from 'lodash.unset';
 import pickBy from 'lodash.pickby';
 import isEmpty from 'lodash.isempty';
-import forIn from 'lodash.forIn';
+import forIn from 'lodash.forin';
 
 export default function createFilter (reducerName, inboundPaths, outboundPaths, transformType = 'whitelist') {
 	return createTransform(

--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@ import { createTransform } from 'redux-persist';
 import get from 'lodash.get';
 import set from 'lodash.set';
 import unset from 'lodash.unset';
+import pickBy from 'lodash.pickby';
+import isEmpty from 'lodash.isempty';
 
 export default function createFilter (reducerName, inboundPaths, outboundPaths, transformType = 'whitelist') {
 	return createTransform(
@@ -31,6 +33,11 @@ export function createBlacklistFilter (reducerName, inboundPaths, outboundPaths)
 	return createFilter(reducerName, inboundPaths, outboundPaths, 'blacklist');
 }
 
+function filterObject({ path, filterFunction = () => true }, state) {
+  const value = get(state, path);
+  return pickBy(value, filterFunction);
+}
+
 export function persistFilter (state, paths = [], transformType = 'whitelist') {
 	let subset = {};
 
@@ -41,20 +48,36 @@ export function persistFilter (state, paths = [], transformType = 'whitelist') {
 
 	if (transformType === 'whitelist') {
 		paths.forEach((path) => {
-			const value = get(state, path);
+			if (typeof path === 'object') {
+				const value = filterObject(path, state);
 
-			if (typeof value !== 'undefined') {
-				set(subset, path, value);
+				if (!isEmpty(value)) {
+					set(subset, path.path, value);
+				}
+			} else {
+				const value = get(state, path);
+
+				if (typeof value !== 'undefined') {
+					set(subset, path, value);
+				}
 			}
 		});
 	} else if (transformType === 'blacklist') {
 		subset = Object.assign({}, state);
 		paths.forEach((path) => {
-			const value = get(state, path);
+			if (typeof path === 'object') {
+				const value = filterObject(path, state);
 
-			if (typeof value !== 'undefined') {
-				unset(subset, path);
-			}
+				if (!isEmpty(value)) {
+					unset(subset, path.path);
+				}
+			} else {
+				const value = get(state, path);
+
+				if (typeof value !== 'undefined') {
+					unset(subset, path);
+				}
+		}
 		});
 	} else {
 		subset = state;

--- a/package.json
+++ b/package.json
@@ -27,11 +27,12 @@
     "url": "https://github.com/edy/redux-persist-transform-filter/issues"
   },
   "dependencies": {
+    "lodash.forin": "^4.4.0",
     "lodash.get": "^4.4.2",
     "lodash.set": "^4.3.2",
     "lodash.unset": "^4.5.2",
     "lodash.isempty": "^4.4.0",
-    "lodash.pickby": "^4.6.0",
+    "lodash.pickby": "^4.6.0"
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
   "dependencies": {
     "lodash.get": "^4.4.2",
     "lodash.set": "^4.3.2",
-    "lodash.unset": "^4.5.2"
+    "lodash.unset": "^4.5.2",
+    "lodash.isempty": "^4.4.0",
+    "lodash.pickby": "^4.6.0",
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",

--- a/spec.js
+++ b/spec.js
@@ -27,6 +27,12 @@ describe('redux-persist-transform-filter', () => {
 			expect(persistFilter({a: {b:'b', c:'c'}, d:'d'}, ['a.b', 'a.c'])).to.deep.equal({a: {b:'b', c:'c'}});
 			expect(persistFilter({a: {b:'b', c:'c'}, d:'d'}, [['a', 'b'], ['a', 'c']])).to.deep.equal({a: {b:'b', c:'c'}});
 		});
+
+		it('should return a subset, given an object that contains a path and a filterFunction', () => {
+			const store = {a:{'id1':{x:true, b:'b'}, 'id2':{x:true, b:'bb'}, 'id3':{x:false, b:'bbb'}}, d:'d'};
+			expect(persistFilter(store, [{ path: 'a', filterFunction: item => item.x }])).to.deep.equal({a:{'id1':{x:true, b:'b'}, 'id2':{x:true, b:'bb'}}});
+			expect(persistFilter(store, [{ path: 'a', filterFunction: item => item.b === 'bb' }])).to.deep.equal({a:{'id2':{x:true, b:'bb'}}});
+		});
 	});
 
 	describe('persistFilter (blacklist)', () => {
@@ -49,6 +55,12 @@ describe('redux-persist-transform-filter', () => {
 			expect(persistFilter({a: {b:'b', c:'c'}, d:'d'}, [['a', 'b']], 'blacklist')).to.deep.equal({a: {c:'c'}, d:'d'});
 			expect(persistFilter({a: {b:'b', c:'c'}, d:'d'}, ['a.b', 'a.c'], 'blacklist')).to.deep.equal({a:{}, d:'d'});
 			expect(persistFilter({a: {b:'b', c:'c'}, d:'d'}, [['a', 'b'], ['a', 'c']], 'blacklist')).to.deep.equal({a:{}, d:'d'});
+		});
+
+		it('should return a subset, given an object that contains a path and a filterFunction', () => {
+			const store = {a:{'id1':{x:true, b:'b'}, 'id2':{x:true, b:'bb'}, 'id3':{x:false, b:'bbb'}}, d:'d'};
+			expect(persistFilter(JSON.parse(JSON.stringify(store)), [{ path: 'a', filterFunction: item => item.x }], 'blacklist')).to.deep.equal({a:{'id3':{x:false, b:'bbb'}}, d:'d'});
+			expect(persistFilter(JSON.parse(JSON.stringify(store)), [{ path: 'a', filterFunction: item => item.b === 'bb' }], 'blacklist')).to.deep.equal({a:{'id1':{x:true, b:'b'}, 'id3':{x:false, b:'bbb'}}, d:'d'});
 		});
 	});
 


### PR DESCRIPTION
If we have a key in the store that is an associative array(stored as Object) we may want to store only a subset of its items that matches a custom predicate.

Suppose we have a reducer `myReducerOne` and its key `itemsList` is an associative array and we want to persist only the items that have the property `mustBeStored ` equals `true`.

To do this we can write:

```js
const saveCustomSubsetFilter = createFilter(
  'myReducerOne',
  [{ path: 'itemsList',
    filterFunction: item => item.mustBeStored }],
);
```

where `path` is the key in the store and `filterFunction `is the function that contains the custom predicate.