### PR TITLE
chore(readme): update example to assign createBlackFilter

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Filter transformator for redux-persist
 ## Usage
 
 ```js
-import createFilter from 'redux-persist-transform-filter';
+import { createFilter, createBlacklistFilter } from 'redux-persist-transform-filter';
 
 // you want to store only a subset of your state of reducer one
 const saveSubsetFilter = createFilter(


### PR DESCRIPTION
Previously, if devs followed the example to the tee, it would result in
a ReferenceError. Updated the README example to correctly assign the
`createBlacklistFilter` function.