### PR TITLE
Typescript definition fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,21 @@ const saveAndloadSubsetFilter = createFilter(
   ['three', 'four']
 );
 
+const predicateFilter = persistFilter(
+	'form',
+	[
+		{ path: 'one', filterFunction: (item: any): boolean => item.mustBeStored },
+		{ path: 'two', filterFunction: (item: any): boolean => item.mustBeStored },
+	],
+	'whitelist'
+)
+
+const normalPathFilter = persistFilter(
+	'form',
+	['one', 'two'],
+	'whitelist'
+)
+
 persistStore(store, {
   transforms: [
     saveSubsetFilter,

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ declare module "redux-persist-transform-filter" {
 	export function createFilter<State, Raw>(reducerName: string, inboundPaths?: string[], outboundPaths?: string[], transformType?: TransformType): Transform<State, Raw>;
 	export function createWhitelistFilter<State, Raw>(reducerName: string, inboundPaths?: string[], outboundPaths?: string[]): Transform<State, Raw>;
 	export function createBlacklistFilter<State, Raw>(reducerName: string, inboundPaths?: string[], outboundPaths?: string[]): Transform<State, Raw>;
-	export function persistFilter<State, Raw>(state: State, paths: string[], transformType: TransformType): Transform<State, Raw>;
+	export function persistFilter<State, Raw>(state: State, paths: string[] | { path: string, filterFunction: ((item: any) => boolean) }[], transformType: TransformType): Transform<State, Raw>;
 
 	export default createFilter;
 }


### PR DESCRIPTION
Thanks for [this PR](https://github.com/edy/redux-persist-transform-filter/pull/8) supported `predicate` that we could filter some items.

But there is something wrong with typescript definitions in https://github.com/edy/redux-persist-transform-filter/pull/14

I have fixed the definitions and add the way how to use persistFilter in README.

Hope it would help, could you please take some time review this PR? Thanks @edy 