### PR TITLE
Make it work for redux keys which are arrays

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -73,7 +73,7 @@ function filterObject(_ref, state) {
 		return true;
 	} : _ref$filterFunction;
 
-	var value = (0, _lodash2.default)(state, path);
+	var value = (0, _lodash2.default)(state, path, state);
 
 	if (value instanceof Array) {
 		return value.filter(filterFunction);
@@ -117,7 +117,7 @@ function persistFilter(state) {
 
 				if (!(0, _lodash10.default)(value)) {
 					if (value instanceof Array) {
-						(0, _lodash4.default)(subset, path.path, (0, _lodash2.default)(subset, path.path).filter(function (x) {
+						(0, _lodash4.default)(subset, path.path, (0, _lodash2.default)(subset, path.path, subset).filter(function (x) {
 							return false;
 						}));
 					} else {
@@ -125,6 +125,8 @@ function persistFilter(state) {
 							(0, _lodash6.default)(subset, path.path + '[' + key + ']');
 						});
 					}
+				} else {
+					subset = value;
 				}
 			} else {
 				var _value2 = (0, _lodash2.default)(state, path);

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ export function createBlacklistFilter (reducerName, inboundPaths, outboundPaths)
 }
 
 function filterObject({ path, filterFunction = () => true }, state) {
-	const value = get(state, path);
+	const value = get(state, path, state);
 
 	if (value instanceof Array) {
 		return value.filter(filterFunction)
@@ -77,11 +77,13 @@ export function persistFilter (state, paths = [], transformType = 'whitelist') {
 
 				if (!isEmpty(value)) {
 					if (value instanceof Array) {
-						set(subset, path.path, get(subset, path.path).filter((x) => false));
+						set(subset, path.path, get(subset, path.path, subset).filter((x) => false));
 					} else {
 						forIn(value, (value, key) => { unset(subset, `${path.path}[${key}]`) });
 					}
-				}
+        } else {
+          subset = value;
+        }
 			} else {
 				const value = get(state, path);
 


### PR DESCRIPTION
If the redux store key is an object, the filter function works. But if the redux store is array itself it will not.

For example the store is like `{myKey: [1,2,3]}` and I want to filter `1` from `mykKey`. With this changes I can do:

```
  const rootReducer = persistCombineReducers(
    {
      key: 'root',
      storage,
      transforms: [
        createBlacklistFilter('myKey', [
          { path: '', filterFunction: i => i !== 1 },
        ]),
      ],
    },
    { ...reducers }
  );
```

Before these changes it failed because `lodash.get` cannot get the whole array. I provided the default value for `lodash.get` so that if the `path` is empty now, the whole array is returned and then can be filtered.